### PR TITLE
feat: add rpc call for getsignaturesforaddress

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -135,6 +135,13 @@ func (c *Client) GetConfirmedSignaturesForAddress2(ctx context.Context, address 
 	return
 }
 
+func (c *Client) GetSignaturesForAddress(ctx context.Context, address solana.PublicKey, opts *GetSignaturesForAddressOpts) (out GetSignaturesForAddressResult, err error) {
+	params := []interface{}{address.String(), opts}
+
+	err := c.rpcClient.CallFor(&out, "getSignaturesForAddress", params...)
+	return
+}
+
 func (c *Client) GetProgramAccounts(ctx context.Context, publicKey solana.PublicKey, opts *GetProgramAccountsOpts) (out GetProgramAccountsResult, err error) {
 	obj := map[string]interface{}{
 		"encoding": "base64",

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -121,6 +121,14 @@ type GetConfirmedSignaturesForAddress2Opts struct {
 
 type GetConfirmedSignaturesForAddress2Result []*TransactionSignature
 
+type GetSignaturesForAddressOpts struct {
+	Limit  uint64 `json:"limit,omitempty"`
+	Before string `json:"before,omitempty"`
+	Until  string `json:"until,omitempty"`
+}
+
+type GetSignaturesForAddressResult []*TransactionSignature
+
 type RPCFilter struct {
 	Memcmp   *RPCFilterMemcmp `json:"memcmp,omitempty"`
 	DataSize bin.Uint64       `json:"dataSize,omitempty"`


### PR DESCRIPTION
The [getconfirmedsignaturesforaddress2](https://docs.solana.com/developing/clients/jsonrpc-api#getconfirmedsignaturesforaddress2) method is expected to be deprecated from Solana v1.8.0. Solana prescribe using the [getsignaturesforaddress](https://docs.solana.com/developing/clients/jsonrpc-api#getsignaturesforaddress) method instead, which has the same interface (options, result as well).

This PR is a simple change adding support for the `getSignaturesforAddress` RPC method.